### PR TITLE
FIX Portuguese returning no label

### DIFF
--- a/code/extensions/TranslatableDataObject.php
+++ b/code/extensions/TranslatableDataObject.php
@@ -116,6 +116,12 @@ class TranslatableDataObject extends DataExtension
 				i18n::get_language_name(i18n::get_lang_from_locale($locale), true),
 				ENT_NOQUOTES, 'UTF-8'));
 			
+			if($langName == false) {
+				$langName = ucfirst(html_entity_decode(
+				i18n::get_language_name($locale, true),
+				ENT_NOQUOTES, 'UTF-8'));
+			}	
+			
 			if(isset($ambiguity[$locale])){
 				$langName .= ' (' . $ambiguity[$locale] . ')';
 			}


### PR DESCRIPTION
Fix to use full locale code (e.g. pt_PT) if no language name returned using just language. This is required as SilverStripe framework i18n file common_languages array sometimes uses the full locale code and not just the two letter language code
