### PR TITLE
Better compatibility with HTMLText Fields

### DIFF
--- a/code/extensions/TranslatableDataObject.php
+++ b/code/extensions/TranslatableDataObject.php
@@ -275,7 +275,7 @@ class TranslatableDataObject extends DataExtension
         $localizedField = $this->getLocalizedFieldName($fieldName);
         
         $value = $this->owner->dbObject($localizedField);
-        if (!$strict && $value == '') {
+        if (!$strict && !$value->exists()) {
             $value = $this->owner->dbObject($fieldName);
         }
 


### PR DESCRIPTION
I got a __toString() error when an HTMLText field was NULL.
This fixes it.

Does it seem to add additional problems ?