### PR TITLE
Ensure that $strict is a boolean value in getLocalizedValue function

### DIFF
--- a/code/extensions/TranslatableDataObject.php
+++ b/code/extensions/TranslatableDataObject.php
@@ -291,6 +291,9 @@ class TranslatableDataObject extends DataExtension
     {
         $localizedField = $this->getLocalizedFieldName($fieldName);
 
+        // ensure that $strict is a boolean value
+        $strict = filter_var($strict, FILTER_VALIDATE_BOOLEAN);
+
         /** @var DBField $value */
         $value = $this->owner->dbObject($localizedField);
         if (!$strict && !$value->exists()) {


### PR DESCRIPTION
The $strict parameter of the getLocalizedValue function wasn't working as expected when called from a template, e.g. with `$T(Title,false)`. The reason was, that the value of $strict is passed as a string from the template and so the !$strict condition always returned false. 