### PR TITLE
Always allow translating on cli and for non-logged users in dev mode

### DIFF
--- a/code/extensions/TranslatableDataObject.php
+++ b/code/extensions/TranslatableDataObject.php
@@ -321,6 +321,10 @@ class TranslatableDataObject extends DataExtension
             $member = Member::currentUser();
         }
 
+        // Always allow on cli and for non-logged users in dev mode
+        if ((!$member && Director::isDev()) || Director::is_cli())
+            return true;
+
         // check for locale
         $allowedLocale = (
             !is_array(Translatable::get_allowed_locales())


### PR DESCRIPTION
The dev/build failed on the CLI (and could also not be called through the browser without the need to login) when we tried to add a translation within the requireDefaultRecords method.